### PR TITLE
Fix: install script and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Audacious Skins Collection
+
+Running `install.sh` should copy all of the zipped skin files into your user's
+`~/.local/share/audacious/Skins` directory. This is one of the default locations
+Audacious looks for skins. Make sure `unzip` is installed on your system, and
+Audacious will be able to read the skin files without unzipping the individual
+skin archives.

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,11 @@
 #!/bin/sh
 
-SCRIPT_DIR=$(readlink -f "$0")
-SRC_DIR="${SCRIPT_DIR}/src"
+SRC_DIR="src"
 
 error_exit() {
     echo "$1" >&2
     exit "${2:-1}"
 }
-
-if [ "$(id -u)" -ne 0 ]; then
-	error_exit "must run script with root privileges"
-fi
 
 if ! command -v audacious >/dev/null; then
     error_exit "Audacious is not installed"
@@ -20,11 +15,7 @@ if [ ! -d "${SRC_DIR}" ]; then
     error_exit "skins directory does not exist"
 fi
 
-DST_DIR="/usr/share/audacious/Skins"
-
-if [ -d "${DST_DIR}" ]; then
-    rm -f "${DST_DIR}"
-fi
+DST_DIR="${HOME}/.local/share/audacious/Skins"
 
 mkdir -p "${DST_DIR}"
 


### PR DESCRIPTION
- change the SRC_DIR directory to point at the local `src` directory in the repository.

- change DST_DIR to point at the user's local audacious skins directory

- don't remove the DST_DIR if it exists (copy should just overwrite)

- add some details to the README about using install.sh